### PR TITLE
Update IAM activity filter

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.1.0
+        uses: triat/terraform-security-scan@v3.0.0

--- a/locals.tf
+++ b/locals.tf
@@ -10,10 +10,10 @@ locals {
 
   iam_activity = merge(
     {
-      Root = "{$.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\"}"
+      Root = "{ $.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"
     },
     var.monitor_iam_activity_sso == true ? {
-      SSO = "{$.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\"}"
+      SSO = "{ $.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\" }"
     } : {}
   )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -10,10 +10,10 @@ locals {
 
   iam_activity = merge(
     {
-      Root = "{ $.userIdentity.type = \"Root\" }"
+      Root = "{$.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\"}"
     },
     var.monitor_iam_activity_sso == true ? {
-      SSO = "{ $.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\" }"
+      SSO = "{$.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\"}"
     } : {}
   )
 }


### PR DESCRIPTION
Updates the IAM activity filters to use the recommended filter for tracking root activity. The recommended filter is the AWS offered way of remediating CIS 1.1: avoiding the use of the root account. I consciously kept the formatting of the check equal to the rule defined in the remediation instruction to make sure it's auto-detected as solved.