### PR TITLE
feature: control the AWS Security Hub standards in member accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ No modules.
 | [aws_ebs_default_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_default_kms_key) | resource |
 | [aws_ebs_encryption_by_default.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
 | [aws_iam_account_password_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
+| [aws_securityhub_standards_subscription.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription) | resource |
 | [aws_cloudwatch_log_group.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -97,6 +99,7 @@ No modules.
 | <a name="input_aws_ebs_encryption_by_default"></a> [aws\_ebs\_encryption\_by\_default](#input\_aws\_ebs\_encryption\_by\_default) | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
 | <a name="input_aws_ebs_encryption_custom_key"></a> [aws\_ebs\_encryption\_custom\_key](#input\_aws\_ebs\_encryption\_custom\_key) | Set to true and specify the `aws_kms_key_arn` to use in place of the AWS-managed default CMK | `bool` | `false` | no |
 | <a name="input_aws_kms_key_arn"></a> [aws\_kms\_key\_arn](#input\_aws\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use to encrypt the EBS volumes | `string` | `null` | no |
+| <a name="input_aws_security_hub_standards_arns"></a> [aws\_security\_hub\_standards\_arns](#input\_aws\_security\_hub\_standards\_arns) | A list of the ARNs of the standards you want to enable in AWS Security Hub. If you do not provide a list the default standards are enabled | `list(string)` | `null` | no |
 | <a name="input_monitor_iam_activity_sns_topic_arn"></a> [monitor\_iam\_activity\_sns\_topic\_arn](#input\_monitor\_iam\_activity\_sns\_topic\_arn) | SNS Topic that should receive captured IAM activity events | `string` | `null` | no |
 | <a name="input_monitor_iam_activity_sso"></a> [monitor\_iam\_activity\_sso](#input\_monitor\_iam\_activity\_sso) | Whether IAM activity from SSO roles should be monitored | `bool` | `true` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ aws_config = {
 }
 ```
 
+## AWS Security Hub
+
+This module enables the following standards by default:
+
+- `AWS Foundational Security Best Practices v1.0.0`
+- `CIS AWS Foundations Benchmark v1.4.0`
+- `PCI DSS v3.2.1`
+
+You are able to control the enabled standards via `var.aws_security_hub_standards_arns`.
+
 ## Monitoring IAM Activity
 
 This module offers the capability of monitoring IAM activity of both the Root user and AWS SSO roles. To enable this feature, you have to provide the ARN of the SNS Topic that should receive events in case any activity is detected.

--- a/data.tf
+++ b/data.tf
@@ -2,3 +2,5 @@ data "aws_cloudwatch_log_group" "cloudtrail" {
   count = var.monitor_iam_activity_sso ? 1 : 0
   name  = "aws-controltower/CloudTrailLogs"
 }
+
+data "aws_region" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -16,4 +16,12 @@ locals {
       SSO = "{ $.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\" }"
     } : {}
   )
+
+  security_hub_standards_arns_default = [
+    "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0",
+    "arn:aws:securityhub:${data.aws_region.current.name}::standards/cis-aws-foundations-benchmark/v/1.4.0",
+    "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
+  ]
+
+  security_hub_standards_arns = var.aws_security_hub_standards_arns != null ? var.aws_security_hub_standards_arns : local.security_hub_standards_arns_default
 }

--- a/main.tf
+++ b/main.tf
@@ -54,3 +54,9 @@ resource "aws_iam_account_password_policy" "default" {
   require_symbols                = var.account_password_policy.require_symbols
   require_uppercase_characters   = var.account_password_policy.require_uppercase_characters
 }
+
+resource "aws_securityhub_standards_subscription" "default" {
+  for_each = toset(local.security_hub_standards_arns)
+
+  standards_arn = each.value
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "aws_kms_key_arn" {
   description = "The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use to encrypt the EBS volumes"
 }
 
+variable "aws_security_hub_standards_arns" {
+  type        = list(string)
+  default     = null
+  description = "A list of the ARNs of the standards you want to enable in AWS Security Hub. If you do not provide a list the default standards are enabled"
+}
+
 variable "monitor_iam_activity_sns_topic_arn" {
   type        = string
   default     = null


### PR DESCRIPTION
This module will now enable the following AWS Security Hub standards by default:

- AAS Foundational Security Best Practices v1.0.0
- CIS AWS Foundations Benchmark v1.4.0
- PCI DSS v3.2.1

Please ensure that `auto-enable default standards` has been turned off in the AWS Security Hub administrator account before upgrading to this version. Note: this has been turned off since [mcaf-landing-zone v1.0.0](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/185)

