### PR TITLE
bug: Fix `aws_cloudwatch_log_group` resource

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,7 @@
 data "aws_cloudwatch_log_group" "cloudtrail" {
-  count = var.monitor_iam_activity_sso ? 1 : 0
-  name  = "aws-controltower/CloudTrailLogs"
+  count = var.monitor_iam_activity_sns_topic_arn != null ? 1 : 0
+
+  name = "aws-controltower/CloudTrailLogs"
 }
 
 data "aws_region" "current" {}


### PR DESCRIPTION
This resource should only exist if a SNS topic ARN is specified,
otherwise `aws_cloudwatch_log_metric_filter.iam_activity` can fail if
the log group is not looked up.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
