### PR TITLE
breaking: Control Tower 3.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,11 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_metric_filter.iam_activity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_metric_filter) | resource |
-| [aws_cloudwatch_metric_alarm.iam_activity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_config_aggregate_authorization.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
 | [aws_ebs_default_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_default_kms_key) | resource |
 | [aws_ebs_encryption_by_default.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
 | [aws_iam_account_password_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_securityhub_standards_subscription.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription) | resource |
-| [aws_cloudwatch_log_group.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_group) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -89,8 +86,6 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 | <a name="input_aws_ebs_encryption_custom_key"></a> [aws\_ebs\_encryption\_custom\_key](#input\_aws\_ebs\_encryption\_custom\_key) | Set to true and specify the `aws_kms_key_arn` to use in place of the AWS-managed default CMK | `bool` | `false` | no |
 | <a name="input_aws_kms_key_arn"></a> [aws\_kms\_key\_arn](#input\_aws\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use to encrypt the EBS volumes | `string` | `null` | no |
 | <a name="input_aws_security_hub_standards_arns"></a> [aws\_security\_hub\_standards\_arns](#input\_aws\_security\_hub\_standards\_arns) | A list of the ARNs of the standards you want to enable in AWS Security Hub. If you do not provide a list the default standards are enabled | `list(string)` | `null` | no |
-| <a name="input_monitor_iam_activity_sns_topic_arn"></a> [monitor\_iam\_activity\_sns\_topic\_arn](#input\_monitor\_iam\_activity\_sns\_topic\_arn) | SNS Topic that should receive captured IAM activity events | `string` | `null` | no |
-| <a name="input_monitor_iam_activity_sso"></a> [monitor\_iam\_activity\_sso](#input\_monitor\_iam\_activity\_sso) | Whether IAM activity from SSO roles should be monitored | `bool` | `true` | no |
 | <a name="input_service_quotas_manager_role"></a> [service\_quotas\_manager\_role](#input\_service\_quotas\_manager\_role) | Create the role needed to integrate the terraform-aws-mcaf-service-quotas-manager module | <pre>object({<br>    assuming_principal_identifier = string<br>    path                          = optional(string, "/")<br>    permissions_boundary          = optional(string, null)<br>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags | `map(string)` | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -45,26 +45,6 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 > [!NOTE]  
 > The Service Quoatas Manager module should be deployed first before deploying this integration. Only existing IAM roles can be referenced as principals.
 
-## Monitoring IAM Activity
-
-This module offers the capability of monitoring IAM activity of both the Root user and AWS SSO roles. To enable this feature, you have to provide the ARN of the SNS Topic that should receive events in case any activity is detected.
-
-The topic ARN can be set using `var.monitor_iam_activity_sns_topic_arn`.
-
-These are two type of events that will be monitored:
-
-- Any activity made by the root user of the account.
-- Any manual changes made by AWS SSO roles (read-only operations and console logins are not taken into account).
-
-In case you would like to NOT monitor AWS SSO role activity, you can set `var.monitor_iam_activity_sso` to `false`.
-
-Example:
-
-```hcl
-monitor_iam_activity_sns_topic_arn = "arn:aws:sns:eu-west-1:123456789012:LandingZone-IAMActivity"
-monitor_iam_activity_sso           = false
-```
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,1 @@
-data "aws_cloudwatch_log_group" "cloudtrail" {
-  count = var.monitor_iam_activity_sns_topic_arn != null ? 1 : 0
-
-  name = "aws-controltower/CloudTrailLogs"
-}
-
 data "aws_region" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -8,15 +8,6 @@ locals {
     ]
   ]) : []
 
-  iam_activity = merge(
-    {
-      Root = "{ $.userIdentity.type=\"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"
-    },
-    var.monitor_iam_activity_sso == true ? {
-      SSO = "{ $.readOnly IS FALSE  && $.userIdentity.sessionContext.sessionIssuer.userName = \"AWSReservedSSO_*\" && $.eventName != \"ConsoleLogin\" }"
-    } : {}
-  )
-
   security_hub_standards_arns_default = [
     "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0",
     "arn:aws:securityhub:${data.aws_region.current.name}::standards/cis-aws-foundations-benchmark/v/1.4.0",

--- a/main.tf
+++ b/main.tf
@@ -1,34 +1,3 @@
-resource "aws_cloudwatch_log_metric_filter" "iam_activity" {
-  for_each = var.monitor_iam_activity_sns_topic_arn != null ? local.iam_activity : {}
-
-  name           = "BaseLine-IAMActivity-${each.key}"
-  pattern        = each.value
-  log_group_name = data.aws_cloudwatch_log_group.cloudtrail[0].name
-
-  metric_transformation {
-    name      = "BaseLine-IAMActivity-${each.key}"
-    namespace = "BaseLine-IAMActivity"
-    value     = "1"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "iam_activity" {
-  for_each = aws_cloudwatch_log_metric_filter.iam_activity
-
-  alarm_name                = each.value.name
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = each.value.name
-  namespace                 = each.value.metric_transformation[0].namespace
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  alarm_description         = "Monitors IAM activity for ${each.key}"
-  alarm_actions             = [var.monitor_iam_activity_sns_topic_arn]
-  insufficient_data_actions = []
-  tags                      = var.tags
-}
-
 resource "aws_config_aggregate_authorization" "default" {
   for_each = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
 

--- a/variables.tf
+++ b/variables.tf
@@ -65,18 +65,6 @@ variable "service_quotas_manager_role" {
   description = "Create the role needed to integrate the terraform-aws-mcaf-service-quotas-manager module"
 }
 
-variable "monitor_iam_activity_sns_topic_arn" {
-  type        = string
-  default     = null
-  description = "SNS Topic that should receive captured IAM activity events"
-}
-
-variable "monitor_iam_activity_sso" {
-  type        = bool
-  default     = true
-  description = "Whether IAM activity from SSO roles should be monitored"
-}
-
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
With the consolidating of the log group 'aws-controltower/CloudTrailLogs' into the management account the log metric and alarms in the enrolled account are removed.

This is related to https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/pull/196 and issue https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/issues/178