### PR TITLE
breaking: add enable_additional_eu_regions variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ module "account_baseline" {
 }
 ```
 
+### EU Region Enablement
+
+By default, this module enables all non-default EU regions (`eu-central-2`, `eu-south-1`, `eu-south-2`). To actually use these regions, they must also be included in the allowed regions SCP of the
+[mcaf-landing-zone module](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone).
+
+This module ensures that you can use all EU regions out of the box. If you intend to allow a region across your entire organization, the recommended approach is to also configure it as a governed region via AWS Control Tower. This ensures consistent enforcement of security, compliance, and operational guardrails.
+
+## Additional Enabled Regions
+
+AWS enables certain regions [by default](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html). Additional regions can be enabled using the `additional_enabled_regions` variable.
+
+> [!WARNING]
+> Enabling regions directly via this module bypasses AWS Control Tower governance.
+> If you need to allow new regions across your organization, the recommended approach is to use AWS Control Tower and configure them as governed regions to ensure consistent security, compliance, and guardrails.
+> However, if you only intend to deploy a small number of resources in a specific region and want to avoid the overhead of Control Tower, this module offers a lightweight alternative to enable that region without governance.
+> You can still add the region as a governed region in Control Tower at a later stage, if needed.
+
 ## AWS Config Rules
 
 If you would like to authorise other accounts to aggregate AWS Config data, account IDs and regions can be passed to `var.aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 
 | Name | Type |
 |------|------|
+| [aws_account_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/account_region) | resource |
 | [aws_config_aggregate_authorization.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/config_aggregate_authorization) | resource |
 | [aws_ebs_default_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_default_kms_key) | resource |
 | [aws_ebs_encryption_by_default.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_encryption_by_default) | resource |
@@ -86,6 +87,7 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 | <a name="input_aws_ec2_image_block_public_access"></a> [aws\_ec2\_image\_block\_public\_access](#input\_aws\_ec2\_image\_block\_public\_access) | Set to true to regionally block new AMIs from being publicly shared | `bool` | `true` | no |
 | <a name="input_aws_kms_key_arn"></a> [aws\_kms\_key\_arn](#input\_aws\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use to encrypt the EBS volumes | `string` | `null` | no |
 | <a name="input_aws_s3_public_access_block_config"></a> [aws\_s3\_public\_access\_block\_config](#input\_aws\_s3\_public\_access\_block\_config) | S3 bucket-level Public Access Block config | <pre>object({<br/>    enabled                 = optional(bool, true)<br/>    block_public_acls       = optional(bool, true)<br/>    block_public_policy     = optional(bool, true)<br/>    ignore_public_acls      = optional(bool, true)<br/>    restrict_public_buckets = optional(bool, true)<br/>  })</pre> | `{}` | no |
+| <a name="input_enable_additional_eu_regions"></a> [enable\_additional\_eu\_regions](#input\_enable\_additional\_eu\_regions) | Enable all additional EU AWS Regions beyond the default ones | `bool` | `true` | no |
 | <a name="input_service_quotas_manager_role"></a> [service\_quotas\_manager\_role](#input\_service\_quotas\_manager\_role) | Create the role needed to integrate the terraform-aws-mcaf-service-quotas-manager module | <pre>object({<br/>    assuming_principal_identifier = string<br/>    path                          = optional(string, "/")<br/>    permissions_boundary          = optional(string, null)<br/>  })</pre> | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags | `map(string)` | `{}` | no |
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,6 @@ By default, this module enables all non-default EU regions (`eu-central-2`, `eu-
 
 This module ensures that you can use all EU regions out of the box. If you intend to allow a region across your entire organization, the recommended approach is to also configure it as a governed region via AWS Control Tower. This ensures consistent enforcement of security, compliance, and operational guardrails.
 
-## Additional Enabled Regions
-
-AWS enables certain regions [by default](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html). Additional regions can be enabled using the `additional_enabled_regions` variable.
-
-> [!WARNING]
-> Enabling regions directly via this module bypasses AWS Control Tower governance.
-> If you need to allow new regions across your organization, the recommended approach is to use AWS Control Tower and configure them as governed regions to ensure consistent security, compliance, and guardrails.
-> However, if you only intend to deploy a small number of resources in a specific region and want to avoid the overhead of Control Tower, this module offers a lightweight alternative to enable that region without governance.
-> You can still add the region as a governed region in Control Tower at a later stage, if needed.
-
 ## AWS Config Rules
 
 If you would like to authorise other accounts to aggregate AWS Config data, account IDs and regions can be passed to `var.aws_config` using the attributes `aggregator_account_ids` and `aggregator_regions` respectively.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,20 +2,32 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v4.0.0
+
+### Key Changes v4.0.0
+
+This version introduces automatic enablement of all non-default EU regions. Previously, users had to opt in to these regions via Control Tower also in use cases where full Control Tower governance was not required. To avoid throttling on large orgs, only non-default EU regions (eu-central-2, eu-south-1, eu-south-2) are enabled by default.
+
+### Variables v4.0.0
+
+The following variables have been added:
+
+- `enable_additional_eu_regions` (`bool`, default: `true`). Toggle automatic opt-in of non-default EU regions. Set to `false` to disable this behavior.
+
 ## Upgrading to v3.0.0
 
-### Key Changes
+### Key Changes v3.0.0
 
 This version sets secure defaults for regional public sharing of EC2 artifacts: block sharing newly created AMIs and EBS snapshots.
 
-### Variables
+### Variables v3.0.0
 
 The following variables have been added:
 
 - `aws_ec2_image_block_public_access`. Set to true to regionally block new AMIs from being publicly shared (false will set to `unblocked`).
 - `aws_ebs_snapshot_block_public_access`. Configure regionally the EBS snapshot public sharing policy (`block-new-sharing`), alternatives: `block-all-sharing` and `unblocked`.
 
-### How to upgrade
+### How to upgrade v3.0.0
 
 If the secure default (blocking new EC2 artifacts from sharing) is what you desire, then no action is required.
 If you want to deploy backwards compatibly, then:
@@ -25,7 +37,7 @@ If you want to deploy backwards compatibly, then:
 
 ## Upgrading to v2.0.0
 
-### Key Changes
+### Key Changes v2.0.0
 
 #### Transition to Centralized Security Hub Configuration
 
@@ -33,13 +45,13 @@ This version relies on the centralized security hub configuration as added in [t
 
 Using centralized security hub it's no longer possible to modify the AWS SecurityHub standards in the account itself, therefore this functionality has been removed from this module.
 
-### Variables
+### Variables v2.0.0
 
 The following variables have been removed:
 
 - `aws_security_hub_standards_arns`. This variable is not configurable anymore using security hub central configuration.
 
-### How to upgrade
+### How to upgrade v2.0.0
 
 1. Upgrade your landing zone deployment to v5.0.0 or higher FIRST, before updating your account-baseline to v2.0.0 or higher.
 

--- a/locals.tf
+++ b/locals.tf
@@ -7,4 +7,10 @@ locals {
       }
     ]
   ]) : []
+
+  regions_to_enable = var.enable_additional_eu_regions ? [
+    "eu-central-2", # Zurich
+    "eu-south-1",   # Milan
+    "eu-south-2",   # Spain
+  ] : []
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,10 @@
+resource "aws_account_region" "default" {
+  for_each = toset(local.regions_to_enable)
+
+  region_name = each.value
+  enabled     = true
+}
+
 resource "aws_config_aggregate_authorization" "default" {
   for_each = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,12 @@ variable "aws_s3_public_access_block_config" {
   description = "S3 bucket-level Public Access Block config"
 }
 
+variable "enable_additional_eu_regions" {
+  description = "Enable all additional EU AWS Regions beyond the default ones"
+  type        = bool
+  default     = true
+}
+
 variable "service_quotas_manager_role" {
   type = object({
     assuming_principal_identifier = string


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
By default, AWS automatically enables a core set of regions (see the [AWS Regions and Endpoints](https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html) documentation). Any other regions must be manually opted in.

In our Landing Zone module we already enforce an SCP on `allowed_regions` ([variables.tf#L302](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone/blob/master/variables.tf#L302)), so from a policy standpoint there’s no difference between “default” and “opt-in” regions. In practice, however, toggling allowed_regions requires you to:
	1.	Remember which regions AWS enables by default versus which require opt-in.
	2.	Opt in to non-default regions via Control Tower—introducing extra overhead not always desired in case the region is only needed to support a small number of resources (e.g., only Bedrock) without wanting full Control Tower governance.

Therefore, the reasoning was to enable all regions by default. Although region opt-in is free and poses no new security risks, AWS does impose some delays and quotas:

**Enablement delay**
- Enabling a region can take a few minutes (for most accounts) and up to several hours in some cases, as AWS propagates IAM and other resources.

**Organization-level quota**
- A management account can have up to 50 pending opt-in/opt-out requests at any time.

**Account-level quota**
- Each member account can have up to 6 pending opt-in/opt-out requests simultaneously.

For full details, see the [AWS Manage Account Regions API Reference](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html).

**Therefore, to avoid long delays and throttling during bootstrapping, this PR limits automatic enablement to the non-default EU regions only—eu-central-2 (Zurich), eu-south-1 (Milan), and eu-south-2 (Spain). These are commonly needed and align with our typical deployment footprint.**