### PR TITLE
breaking: block public ssm document sharing by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,11 @@ resource "aws_s3_account_public_access_block" "default" {
   restrict_public_buckets = var.aws_s3_public_access_block_config.restrict_public_buckets
 }
 
+resource "aws_ssm_service_setting" "document_public_sharing_permission" {
+  setting_id    = "/ssm/documents/console/public-sharing-permission"
+  setting_value = var.aws_ssm_document_public_sharing_permission
+}
+
 module "service_quota_manager_role" {
   count = var.service_quotas_manager_role != null ? 1 : 0
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Allow blocking public SSM document sharing.

## :rocket: Motivation

Publicly sharing SSM documents is almost always undesired.
Better build a guard rails to prevent mistakes.

## :pencil: Additional Information

[Related Security Hub control](https://docs.aws.amazon.com/securityhub/latest/userguide/ssm-controls.html#ssm-7)
