### PR TITLE
fix: ensure regions to baseline is an distinct list of values

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -16,8 +16,8 @@ locals {
     "eu-south-2",   # Spain
   ] : []
 
-  regions_to_baseline = concat(
+  regions_to_baseline = distinct(concat(
     [data.aws_region.current.region],
     var.extra_regions_to_baseline
-  )
+  ))
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary
By adding a distinct function to the `regions_to_baseline` local this ensures that if the end user adds the default region to the `extra_regions_to_baseline` variable as well the behaviour stays the same making the module more failproof to work with and allows for easier to calculate input in some use cases. 

## :rocket: Motivation

See Summary
