### PR TITLE
feat!: align variable naming with mcaf-landing-zone and solve deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_regional_resources_baseline"></a> [regional\_resources\_baseline](#module\_regional\_resources\_baseline) | ./modules/regional-resources-baseline | n/a |
-| <a name="module_service_quota_manager_role"></a> [service\_quota\_manager\_role](#module\_service\_quota\_manager\_role) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
+| <a name="module_service_quota_manager_role"></a> [service\_quota\_manager\_role](#module\_service\_quota\_manager\_role) | schubergphilis/mcaf-role/aws | ~> 0.5.3 |
 
 ## Resources
 
@@ -83,8 +83,8 @@ This module can deploy the IAM role required by the [MCAF Service Quotas Manager
 | <a name="input_aws_config"></a> [aws\_config](#input\_aws\_config) | AWS Config settings | <pre>object({<br/>    aggregator_account_ids = list(string)<br/>    aggregator_regions     = list(string)<br/>  })</pre> | `null` | no |
 | <a name="input_aws_ebs_encryption_by_default"></a> [aws\_ebs\_encryption\_by\_default](#input\_aws\_ebs\_encryption\_by\_default) | Set to true to enable AWS Elastic Block Store encryption by default | `bool` | `true` | no |
 | <a name="input_aws_ebs_encryption_custom_key"></a> [aws\_ebs\_encryption\_custom\_key](#input\_aws\_ebs\_encryption\_custom\_key) | Set to true and specify the `aws_kms_key_arn` to use in place of the AWS-managed default CMK | `bool` | `false` | no |
-| <a name="input_aws_ebs_snapshot_block_public_access"></a> [aws\_ebs\_snapshot\_block\_public\_access](#input\_aws\_ebs\_snapshot\_block\_public\_access) | Configure regionally the EBS snapshot public sharing policy, alternatives: `block-all-sharing` and `unblocked` | `string` | `"block-new-sharing"` | no |
-| <a name="input_aws_ec2_image_block_public_access"></a> [aws\_ec2\_image\_block\_public\_access](#input\_aws\_ec2\_image\_block\_public\_access) | Set to true to regionally block new AMIs from being publicly shared | `bool` | `true` | no |
+| <a name="input_aws_ebs_snapshot_block_public_access_state"></a> [aws\_ebs\_snapshot\_block\_public\_access\_state](#input\_aws\_ebs\_snapshot\_block\_public\_access\_state) | Configure regionally the EBS snapshot public sharing policy, alternatives: `block-all-sharing` and `unblocked` | `string` | `"block-new-sharing"` | no |
+| <a name="input_aws_ec2_image_block_public_access_state"></a> [aws\_ec2\_image\_block\_public\_access\_state](#input\_aws\_ec2\_image\_block\_public\_access\_state) | Configure blocking new AMIs from being publicly shared, alternatives: `unblocked` | `string` | `"block-new-sharing"` | no |
 | <a name="input_aws_kms_key_arn"></a> [aws\_kms\_key\_arn](#input\_aws\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use to encrypt the EBS volumes | `string` | `null` | no |
 | <a name="input_aws_s3_public_access_block_config"></a> [aws\_s3\_public\_access\_block\_config](#input\_aws\_s3\_public\_access\_block\_config) | S3 bucket-level Public Access Block config | <pre>object({<br/>    enabled                 = optional(bool, true)<br/>    block_public_acls       = optional(bool, true)<br/>    block_public_policy     = optional(bool, true)<br/>    ignore_public_acls      = optional(bool, true)<br/>    restrict_public_buckets = optional(bool, true)<br/>  })</pre> | `{}` | no |
 | <a name="input_aws_ssm_documents_public_sharing_permission"></a> [aws\_ssm\_documents\_public\_sharing\_permission](#input\_aws\_ssm\_documents\_public\_sharing\_permission) | Configure the SSM documents public sharing policy, alternatives: `Enable` | `string` | `"Disable"` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,21 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v6.0.0
+
+### Key Changes v6.0.0
+
+- Align variable naming between the [mcaf-landing-zone](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone) module and this module.
+- Upgrade dependencies to latest version.
+- Solve deprecation warning of the `aws_config_aggregate_authorization` resource. This will result in a recreation. This cannot be prevented with a moved statement, but it has no impact — the resource will be deleted and recreated within a few seconds.
+
+### Variables v6.0.0
+
+The following variables have been renamed:
+
+- `aws_ec2_image_block_public_access` -> `aws_ebs_snapshot_block_public_access_state`. Note that the type changed from a `bool` to a `string` as well. The default behaviour out of the box stayed the same. 
+- `aws_ebs_snapshot_block_public_access` -> `aws_ec2_image_block_public_access_state`.
+
 ## Upgrading to v5.0.0
 
 ### Key Changes v5.0.0

--- a/main.tf
+++ b/main.tf
@@ -8,9 +8,9 @@ resource "aws_account_region" "default" {
 resource "aws_config_aggregate_authorization" "default" {
   for_each = { for aggregator in local.aws_config_aggregators : "${aggregator.account_id}-${aggregator.region}" => aggregator }
 
-  account_id = each.value.account_id
-  region     = each.value.region
-  tags       = var.tags
+  account_id            = each.value.account_id
+  authorized_aws_region = each.value.region
+  tags                  = var.tags
 }
 
 resource "aws_ebs_default_kms_key" "default" {
@@ -35,7 +35,7 @@ resource "aws_iam_account_password_policy" "default" {
 # This is set regionally, but enforced account-wide, see:
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/manage-block-public-access-for-amis.html#enable-block-public-access-for-amis
 resource "aws_ec2_image_block_public_access" "default" {
-  state = var.aws_ec2_image_block_public_access ? "block-new-sharing" : "unblocked"
+  state = var.aws_ec2_image_block_public_access_state
 }
 
 resource "aws_s3_account_public_access_block" "default" {
@@ -54,7 +54,7 @@ module "regional_resources_baseline" {
 
   region                                      = each.value
   aws_ebs_encryption_by_default               = var.aws_ebs_encryption_by_default
-  aws_ebs_snapshot_block_public_access_state  = var.aws_ebs_snapshot_block_public_access
+  aws_ebs_snapshot_block_public_access_state  = var.aws_ebs_snapshot_block_public_access_state
   aws_ssm_documents_public_sharing_permission = var.aws_ssm_documents_public_sharing_permission
 }
 
@@ -62,7 +62,7 @@ module "service_quota_manager_role" {
   count = var.service_quotas_manager_role != null ? 1 : 0
 
   source  = "schubergphilis/mcaf-role/aws"
-  version = "~> 0.4.0"
+  version = "~> 0.5.3"
 
   name                  = "ServiceQuotasManager"
   create_policy         = true

--- a/variables.tf
+++ b/variables.tf
@@ -49,20 +49,25 @@ variable "aws_kms_key_arn" {
   description = "The ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use to encrypt the EBS volumes"
 }
 
-variable "aws_ec2_image_block_public_access" {
-  type        = bool
-  default     = true
-  description = "Set to true to regionally block new AMIs from being publicly shared"
+variable "aws_ec2_image_block_public_access_state" {
+  type        = string
+  default     = "block-new-sharing"
+  description = "Configure blocking new AMIs from being publicly shared, alternatives: `unblocked`"
+
+  validation {
+    condition     = contains(["block-new-sharing", "unblocked"], var.aws_ec2_image_block_public_access_state)
+    error_message = "Allowed values for aws_ec2_image_block_public_access_state are: \"block-new-sharing\", \"unblocked\"."
+  }
 }
 
-variable "aws_ebs_snapshot_block_public_access" {
+variable "aws_ebs_snapshot_block_public_access_state" {
   type        = string
   default     = "block-new-sharing"
   description = "Configure regionally the EBS snapshot public sharing policy, alternatives: `block-all-sharing` and `unblocked`"
 
   validation {
-    condition     = contains(["unblocked", "block-new-sharing", "block-all-sharing"], var.aws_ebs_snapshot_block_public_access)
-    error_message = "Allowed values for aws_ebs_snapshot_block_public_access are: \"unblocked\", \"block-new-sharing\", \"block-all-sharing\"."
+    condition     = contains(["unblocked", "block-new-sharing", "block-all-sharing"], var.aws_ebs_snapshot_block_public_access_state)
+    error_message = "Allowed values for aws_ebs_snapshot_block_public_access_state are: \"unblocked\", \"block-new-sharing\", \"block-all-sharing\"."
   }
 }
 


### PR DESCRIPTION
## :hammer_and_wrench: Summary
- Align variable naming between the [mcaf-landing-zone](https://github.com/schubergphilis/terraform-aws-mcaf-landing-zone) module and this module.
- Upgrade dependencies to latest version.
- Solve deprecation warning of the `aws_config_aggregate_authorization` resource. This will result in a recreation. This cannot be prevented with a moved statement, but it has no impact — the resource will be deleted and recreated within a few seconds.

## :rocket: Motivation

The mcaf-landing-zone module is going to use this module for baselining the core accounts instead of similar submodules. Consistent naming and typing is therefore needed to prevent confusion and to simplify the code. 
