### PR TITLE
bug: solve known after apply issue with the aws_ebs_default_kms_key resource

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,7 +7,7 @@ This document captures required refactoring on your part when upgrading to a mod
 ### Key Changes v7.0.0
 
 - Switch from a single `aws_kms_key_arn` to a per-region map `aws_kms_key_arns` variable.
-- Creates/attaches the EBS default KMS key only if a key for the region is provided and `aws_ebs_encryption_custom_key = true`.
+- Creates/attaches the EBS default KMS key if `aws_ebs_encryption_custom_key = true`.
 - Sets the SSM Automation log group `kms_key_id` if a key for the region is provided.
 - multi-region support for the `aws_ebs_default_kms_key` resource is added.
 

--- a/modules/regional-resources-baseline/main.tf
+++ b/modules/regional-resources-baseline/main.tf
@@ -7,7 +7,7 @@ resource "aws_ebs_encryption_by_default" "default" {
 
 # Default KMS key to use for EBS encryption
 resource "aws_ebs_default_kms_key" "default" {
-  count = var.aws_ebs_encryption_custom_key && try(var.aws_kms_key_arns[var.region], null) != null ? 1 : 0
+  count = var.aws_ebs_encryption_custom_key ? 1 : 0
 
   region  = var.region
   key_arn = var.aws_kms_key_arns[var.region]


### PR DESCRIPTION
## :hammer_and_wrench: Summary

When creating the KMS key and deploying the account-baseline in the same run the following error occurs:

```
Error: Invalid count argument
on .terraform/modules/account_baseline/modules/regional-resources-baseline/main.tf line 10, in resource "aws_ebs_default_kms_key" "default":

  count = var.aws_ebs_encryption_custom_key && try(var.aws_kms_key_arns[var.region], null) != null ? 1 : 0

The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot predict how many instances will be created. To work around this, use the -target argument to first apply only the resources that the count depends on.
```
