### PR TITLE
feature: require unmanaged ebs BPA with declarative policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,15 +49,16 @@ module "regional_resources_baseline" {
 
   source = "./modules/regional-resources-baseline"
 
-  region                                      = each.value
-  aws_ebs_encryption_by_default               = var.aws_ebs_encryption_by_default
-  aws_ebs_encryption_custom_key               = var.aws_ebs_encryption_custom_key
-  aws_ebs_snapshot_block_public_access_state  = var.aws_ebs_snapshot_block_public_access_state
-  aws_kms_key_arns                            = var.aws_kms_key_arns
-  aws_ssm_automation_log_group_name           = var.aws_ssm_automation_log_group_name
-  aws_ssm_automation_logging_enabled          = var.aws_ssm_automation_logging_enabled
-  aws_ssm_documents_public_sharing_permission = var.aws_ssm_documents_public_sharing_permission
-  tags                                        = var.tags
+  region                                           = each.value
+  aws_ebs_encryption_by_default                    = var.aws_ebs_encryption_by_default
+  aws_ebs_encryption_custom_key                    = var.aws_ebs_encryption_custom_key
+  aws_ebs_snapshot_block_public_access_state       = var.aws_ebs_snapshot_block_public_access_state
+  manage_ebs_snapshot_block_public_access_resource = var.manage_ebs_snapshot_block_public_access_resource
+  aws_kms_key_arns                                 = var.aws_kms_key_arns
+  aws_ssm_automation_log_group_name                = var.aws_ssm_automation_log_group_name
+  aws_ssm_automation_logging_enabled               = var.aws_ssm_automation_logging_enabled
+  aws_ssm_documents_public_sharing_permission      = var.aws_ssm_documents_public_sharing_permission
+  tags                                             = var.tags
 }
 
 module "service_quota_manager_role" {

--- a/modules/regional-resources-baseline/main.tf
+++ b/modules/regional-resources-baseline/main.tf
@@ -15,10 +15,12 @@ resource "aws_ebs_default_kms_key" "default" {
 
 # Security Hub control: EC2.1
 resource "aws_ebs_snapshot_block_public_access" "default" {
+  count  = var.manage_ebs_snapshot_block_public_access_resource ? 1 : 0
   region = var.region
 
   state = var.aws_ebs_snapshot_block_public_access_state
 }
+
 
 # Security Hub control: SSM.6
 resource "aws_ssm_service_setting" "automation_log_destination" {

--- a/modules/regional-resources-baseline/variables.tf
+++ b/modules/regional-resources-baseline/variables.tf
@@ -15,6 +15,11 @@ variable "aws_ebs_snapshot_block_public_access_state" {
   type = string
 }
 
+variable "manage_ebs_snapshot_block_public_access_resource" {
+  type    = bool
+  default = true
+}
+
 variable "aws_kms_key_arns" {
   type    = map(string)
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -66,9 +66,23 @@ variable "aws_ebs_snapshot_block_public_access_state" {
   description = "Configure regionally the EBS snapshot public sharing policy, alternatives: `block-all-sharing` and `unblocked`"
 
   validation {
-    condition     = contains(["unblocked", "block-new-sharing", "block-all-sharing"], var.aws_ebs_snapshot_block_public_access_state)
-    error_message = "Allowed values for aws_ebs_snapshot_block_public_access_state are: \"unblocked\", \"block-new-sharing\", \"block-all-sharing\"."
+    condition = (
+      var.manage_ebs_snapshot_block_public_access_resource == true &&
+      contains(["unblocked", "block-new-sharing", "block-all-sharing"], var.aws_ebs_snapshot_block_public_access_state)
+      ||
+      (
+        var.manage_ebs_snapshot_block_public_access_resource == false
+      )
+    )
+    error_message = "Allowed values for aws_ebs_snapshot_block_public_access_state are: \"unblocked\", \"block-new-sharing\", \"block-all-sharing\" when manage_ebs_snapshot_block_public_access_resource is true"
   }
+}
+
+variable "manage_ebs_snapshot_block_public_access_resource" {
+  type        = bool
+  default     = true
+  description = "When Declarative policies are enabled this resource should be unmanaged else keep as is."
+
 }
 
 variable "aws_ssm_automation_logging_enabled" {

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 6.7.0"
     }
   }
-  required_version = ">= 1.7.0"
+  required_version = ">= 1.9.0"
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->
<!-- You can include the GitHub generated Summary, be sure to review and clean up appropriately. -->

When utilizing Declarative policies at an organization level, the resource `aws_ebs_snapshot_block_public_access` conflicts and cannot be created causing baseline issues.

For instance:

```
Error: enabling EBS Snapshot Block Public Access (block-new-sharing): operation error EC2: EnableSnapshotBlockPublicAccess, https response error StatusCode: 400, RequestID: 777e60f1-a40f-4e18-b77d-915184741663, api error DeclarativePolicyViolation: This functionality has been disabled by a Declarative Policy. Custom Message: VPC block public access policy is enforced for this account at the organization level.
```

## :rocket: Motivation

<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to online docs or images that may help with reviewing the PR. -->
